### PR TITLE
Change ballerina archive extension to bala

### DIFF
--- a/choreo-extension-ballerina/build.gradle
+++ b/choreo-extension-ballerina/build.gradle
@@ -94,8 +94,8 @@ task copyStdlibs(type: Copy) {
     /* Standard Libraries */
     configurations.ballerinaStdLibs.resolvedConfiguration.resolvedArtifacts.each { artifact ->
         def artifactExtractedPath = "${buildDir}/extracted-distributions/" + artifact.name + "-zip"
-        into("repo/balo") {
-            from "${artifactExtractedPath}/balo"
+        into("repo/bala") {
+            from "${artifactExtractedPath}/bala"
         }
         into("repo/cache") {
             from "${artifactExtractedPath}/cache"
@@ -171,8 +171,8 @@ task ballerinaBuild {
             }
         }
         copy {
-            from file("${project.projectDir}/target/balo")
-            into file("$artifactCacheParent/balo/${packageOrg}/${packageName}/${tomlVersion}")
+            from file("${project.projectDir}/target/bala")
+            into file("$artifactCacheParent/bala/${packageOrg}/${packageName}/${tomlVersion}")
         }
         copy {
             from file("${project.projectDir}/target/cache")

--- a/choreo-extension-tests/build.gradle
+++ b/choreo-extension-tests/build.gradle
@@ -81,8 +81,8 @@ def copyDistributions (distributionConfigurations) {
         /* Standard Libraries */
         distributionConfigurations.resolvedConfiguration.resolvedArtifacts.each { artifact ->
             def artifactExtractedPath = "${project.buildDir}/extracted-distributions/" + artifact.name + "-zip"
-            into("repo/balo") {
-                from "${artifactExtractedPath}/balo"
+            into("repo/bala") {
+                from "${artifactExtractedPath}/bala"
             }
             into("repo/cache") {
                 from "${artifactExtractedPath}/cache"


### PR DESCRIPTION
## Purpose
> Renames the extension of the package distribution file from balo to bala 
> Fixes ballerina-platform/ballerina-lang#28476 