### PR TITLE
Change traceId and spanId type to String telemetry side

### DIFF
--- a/choreo-extension-native/src/main/java/io/ballerina/observe/choreo/client/ChoreoClient.java
+++ b/choreo-extension-native/src/main/java/io/ballerina/observe/choreo/client/ChoreoClient.java
@@ -185,8 +185,8 @@ public class ChoreoClient implements AutoCloseable {
                 ChoreoTraceSpan traceSpan = traceSpans.get(i);
                 TelemetryOuterClass.TraceSpan.Builder traceSpanBuilder
                         = TelemetryOuterClass.TraceSpan.newBuilder()
-                                                       .setTraceId(traceSpan.getTraceId())
-                                                       .setSpanId(traceSpan.getSpanId())
+                                                       .setTraceId(Long.toString(traceSpan.getTraceId()))
+                                                       .setSpanId(Long.toString(traceSpan.getSpanId()))
                                                        .setServiceName(traceSpan.getServiceName())
                                                        .setOperationName(traceSpan.getOperationName())
                                                        .setTimestamp(traceSpan.getTimestamp())
@@ -194,8 +194,8 @@ public class ChoreoClient implements AutoCloseable {
                                                        .putAllTags(traceSpan.getTags());
                 for (ChoreoTraceSpan.Reference reference : traceSpan.getReferences()) {
                     traceSpanBuilder.addReferences(TelemetryOuterClass.TraceSpanReference.newBuilder()
-                            .setTraceId(reference.getTraceId())
-                            .setSpanId(reference.getSpanId())
+                            .setTraceId(Long.toString(reference.getTraceId()))
+                            .setSpanId(Long.toString(reference.getSpanId()))
                             .setRefType(reference.getRefType() == ChoreoTraceSpan.Reference.Type.CHILD_OF
                                     ? TelemetryOuterClass.TraceReferenceType.CHILD_OF
                                     : TelemetryOuterClass.TraceReferenceType.FOLLOWS_FROM));

--- a/choreo-extension-native/src/main/proto/telemetry.proto
+++ b/choreo-extension-native/src/main/proto/telemetry.proto
@@ -37,8 +37,8 @@ message TracesPublishRequest {
 }
 
 message TraceSpan {
-    uint64 traceId = 1;
-    uint64 spanId = 2;
+    string traceId = 1;
+    string spanId = 2;
     string serviceName = 3;
     string operationName = 4;
     int64 timestamp = 5;
@@ -49,8 +49,8 @@ message TraceSpan {
 }
 
 message TraceSpanReference {
-    uint64 traceId = 1;
-    uint64 spanId = 2;
+    string traceId = 1;
+    string spanId = 2;
     TraceReferenceType refType = 3;
 }
 

--- a/choreo-extension-native/src/main/proto/telemetry.proto
+++ b/choreo-extension-native/src/main/proto/telemetry.proto
@@ -1,5 +1,5 @@
 syntax = "proto3";
-package v0_1_2;
+package v0_2_0;
 
 option java_package = "io.ballerina.observe.choreo.gen";
 


### PR DESCRIPTION
Change traceId and spanId type to String in telemetry side because we plan to move from opentracing to opentelemetry and and traceId and spanId are of string type in opentelemetry.
First we change the telemetry side so that we can make the change in telemetry service component.

https://github.com/ballerina-platform/ballerina-lang/issues/28351