### PR TITLE
Add support to automatically push the releases to Ballerina Central

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,36 +5,6 @@
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![codecov](https://codecov.io/gh/ballerina-platform/module-ballerinax-choreo/branch/main/graph/badge.svg?token=YFBSFSOND4)](https://codecov.io/gh/ballerina-platform/module-ballerinax-choreo)
 
-The Choreo Observability Extension is one of the observability extensions of the<a target="_blank" href="https://ballerina.io/"> Ballerina</a> language.
-
-It provides an implementation for publishing traces & metrics to Choreo.
-
-## Enabling Choreo Extension
-
-To package the Choreo extension into the Jar, follow the following steps.
-1. Add the following import to your program.
-```ballerina
-import ballerinax/choreo as _;
-```
-
-2. Add the following to the `Ballerina.toml` when building your program.
-```toml
-[package]
-org = "my_org"
-name = "my_package"
-version = "1.0.0"
-
-[build-options]
-observabilityIncluded=true
-```
-
-To enable the extension and connect to Choreo, add the following to the `Config.toml` when running your program.
-```toml
-[ballerina.observe]
-enabled=true
-provider="choreo"
-```
-
 ## Building from the Source
 
 ### Setting Up the Prerequisites

--- a/build.gradle
+++ b/build.gradle
@@ -224,13 +224,11 @@ subprojects {
     }
 }
 
-def moduleVersion = project.version
-if (moduleVersion.indexOf('-') != -1) {
-    moduleVersion = moduleVersion.substring(0, moduleVersion.indexOf('-'))
-}
+def moduleVersion = project.version.replace("-SNAPSHOT", "")
 
 release {
     failOnPublishNeeded = false
+    failOnSnapshotDependencies = true
 
     buildTasks = ['build']
     versionPropertyFile = 'gradle.properties'

--- a/choreo-extension-ballerina/Package.md
+++ b/choreo-extension-ballerina/Package.md
@@ -1,0 +1,31 @@
+## Package Overview
+
+The Choreo Observability Extension is one of the observability extensions of the<a target="_blank" href="https://ballerina.io/"> Ballerina</a> language.
+
+It provides an implementation for publishing traces & metrics to Choreo.
+
+## Enabling Choreo Extension
+
+To package the Choreo extension into the Jar, follow the following steps.
+1. Add the following import to your program.
+```ballerina
+import ballerinax/choreo as _;
+```
+
+2. Add the following to the `Ballerina.toml` when building your program.
+```toml
+[package]
+org = "my_org"
+name = "my_package"
+version = "1.0.0"
+
+[build-options]
+observabilityIncluded=true
+```
+
+To enable the extension and connect to Choreo, add the following to the `Config.toml` when running your program.
+```toml
+[ballerina.observe]
+enabled=true
+provider="choreo"
+```

--- a/choreo-extension-ballerina/build.gradle
+++ b/choreo-extension-ballerina/build.gradle
@@ -128,6 +128,7 @@ def originalConfig = ballerinaConfigFile.text
 def originalDependencyConfig = ballerinaDependencyFile.text
 def artifactJar = file("$project.projectDir/target/cache/${packageOrg}/${packageName}/${tomlVersion}/java11/")
 def platform = "java11"
+def distributionBinPath = "${project.buildDir.absolutePath}/extracted-distributions/jballerina-tools-zip/jballerina-tools-${ballerinaLangVersion}/bin"
 
 def stripBallerinaExtensionVersion(String extVersion) {
     if (extVersion.matches(project.ext.timestampedVersionRegex)) {
@@ -191,8 +192,6 @@ task ballerinaBuild {
     finalizedBy(revertTomlFile)
 
     doLast {
-        def distributionBinPath = "${project.buildDir.absolutePath}/extracted-distributions/jballerina-tools-zip/jballerina-tools-${ballerinaLangVersion}/bin"
-
         def additionalBuildParams = ""
         if (project.hasProperty("debug")) {
             additionalBuildParams = "--debug ${project.findProperty("debug")}"
@@ -221,21 +220,6 @@ task ballerinaBuild {
             into file("$artifactCacheParent/cache/")
         }
 
-        // Publish to central
-        if (!project.version.endsWith('-SNAPSHOT') && project.version.matches(project.ext.timestampedVersionRegex) &&
-                ballerinaCentralAccessToken != null && project.hasProperty("publishToCentral")) {
-            println("Publishing to the ballerina central..")
-            exec {
-                workingDir project.projectDir
-                environment "JAVA_OPTS", "-DBALLERINA_DEV_COMPILE_BALLERINA_ORG=true"
-                if (Os.isFamily(Os.FAMILY_WINDOWS)) {
-                    commandLine 'cmd', '/c', "$distributionBinPath/bal.bat push && exit %%ERRORLEVEL%%"
-                } else {
-                    commandLine 'sh', '-c', "$distributionBinPath/bal push"
-                }
-            }
-
-        }
         // Doc creation and packing
         exec {
             workingDir project.projectDir
@@ -266,6 +250,34 @@ artifacts {
     distribution createArtifactZip
 }
 
+task ballerinaPublish {
+    dependsOn updateTomlVerions
+    dependsOn ballerinaBuild
+    dependsOn ":${packageName}-extension-tests:test"
+
+    finalizedBy(revertTomlFile)
+
+    doLast {
+        if (project.version.endsWith('-SNAPSHOT')) {
+            return
+        }
+        if (ballerinaCentralAccessToken != null) {
+            println("Publishing to the ballerina central...")
+            exec {
+                workingDir project.projectDir
+                environment "JAVA_OPTS", "-DBALLERINA_DEV_COMPILE_BALLERINA_ORG=true"
+                if (Os.isFamily(Os.FAMILY_WINDOWS)) {
+                    commandLine 'cmd', '/c', "$distributionBinPath/bal.bat push && exit %%ERRORLEVEL%%"
+                } else {
+                    commandLine 'sh', '-c', "$distributionBinPath/bal push"
+                }
+            }
+        } else {
+            throw new InvalidUserDataException("Central Access Token is not present")
+        }
+    }
+}
+
 publishing {
     publications {
         mavenJava(MavenPublication) {
@@ -287,6 +299,10 @@ publishing {
 
 build {
     dependsOn ballerinaBuild
+}
+
+publish {
+    dependsOn ballerinaPublish
 }
 
 task extractBallerinaClassFiles(type: Copy) {


### PR DESCRIPTION
## Purpose
> Add support to automatically push the releases to Ballerina Central.

## Goals
> Since, the Choreo extension is removed from the Ballerina Distribution, the package needs to be pushed to Ballerina Central so that users can use it.

## Approach
> Push the Ballerina packages to Ballerina Central in the Publish Release workflow.