### PR TITLE
Remove duplicate Jar already available in ballerina-rt

### DIFF
--- a/choreo-extension-ballerina/Ballerina.toml
+++ b/choreo-extension-ballerina/Ballerina.toml
@@ -32,12 +32,6 @@ artifactId = "jaeger-core"
 version = "@jaeger.version@"
 
 [[platform.java11.dependency]]
-path = "./lib/opentelemetry-api-@opentelemetry.version@.jar"
-groupId = "io.opentelemetry"
-artifactId = "opentelemetry-api"
-version = "@opentelemetry.version@"
-
-[[platform.java11.dependency]]
 path = "./lib/opentelemetry-context-@opentelemetry.version@.jar"
 groupId = "io.opentelemetry"
 artifactId = "opentelemetry-context"

--- a/choreo-extension-ballerina/build.gradle
+++ b/choreo-extension-ballerina/build.gradle
@@ -35,7 +35,6 @@ dependencies {
     nativeJar project(':choreo-extension-native')
 
     externalJars "io.jaegertracing:jaeger-core:${jaegerVersion}"
-    externalJars "io.opentelemetry:opentelemetry-api:${openTelemetryVersion}"
     externalJars "io.opentelemetry:opentelemetry-context:${openTelemetryVersion}"
     externalJars "io.opentelemetry:opentelemetry-sdk-common:${openTelemetryVersion}"
     externalJars "io.opentelemetry:opentelemetry-sdk-trace:${openTelemetryVersion}"


### PR DESCRIPTION
## Purpose
> Remove a duplicated Jar which is already present (Refer: https://github.com/ballerina-platform/ballerina-lang/blob/530658ec57b69f46f9b396a404ccf40b1e3f2106/bvm/ballerina-rt/build.gradle#L97) in the runtime Jar which is causing warnings in the build log.

## Goals
> Remove warnings in build log.