### PR TITLE
Bump release version after node ID fix release

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 group=org.ballerinalang
-version=0.2.8-SNAPSHOT
+version=0.3.0-SNAPSHOT
 ballerinaLangVersion=2.0.0-beta.1-20210531-213400-7cdb0fb5
 org.gradle.caching=true
 org.gradle.parallel=true


### PR DESCRIPTION
## Purpose
> Bump release version after node ID fix release (https://github.com/ballerina-platform/module-ballerinax-choreo/releases/tag/v0.2.8)