### PR TITLE
Bump Choreo Extension version to 0.4.0

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 group=org.ballerinalang
-version=0.3.1-SNAPSHOT
+version=0.4.0-SNAPSHOT
 ballerinaLangVersion=2.0.0-beta.3-20210721-100000-3e8a6e98
 org.gradle.caching=true
 org.gradle.parallel=true


### PR DESCRIPTION
## Purpose
> Since a separate version needs to be released for Balelrina Swan Lake Beta 2 (0.3.x versions), the Choreo extension version had been bumped to `0.4.0`