### PR TITLE
Bump choreo extension version to 0.4.1

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 group=org.ballerinalang
-version=0.4.0-SNAPSHOT
+version=0.4.1-SNAPSHOT
 ballerinaLangVersion=2.0.0-beta.3-20211007-144400-9ab36aea
 org.gradle.caching=true
 org.gradle.parallel=true


### PR DESCRIPTION
## Purpose
> Due to the failure in extension publish flow due to issues with ballerina/observe module, the version had to be bumped

## Goals
> Publish choreo extension version for SL Beta 3

## Approach
> Bump choreo extension version to 0.4.1
