### PR TITLE
Fix CVE-2026-45292: upgrade opentelemetry-api to 1.63.0

### DIFF
--- a/choreo-extension-ballerina/Ballerina.toml
+++ b/choreo-extension-ballerina/Ballerina.toml
@@ -51,12 +51,6 @@ artifactId = "opentelemetry-semconv"
 version = "@openTelemetryAlpha.version@"
 
 [[platform.java17.dependency]]
-path = "./lib/opentelemetry-api-metrics-@openTelemetryAlpha.version@.jar"
-groupId = "io.opentelemetry"
-artifactId = "opentelemetry-api-metrics"
-version = "@openTelemetryAlpha.version@"
-
-[[platform.java17.dependency]]
 path = "./lib/opentelemetry-extension-trace-propagators-@opentelemetry.version@.jar"
 groupId = "io.opentelemetry"
 artifactId = "opentelemetry-extension-trace-propagators"

--- a/choreo-extension-ballerina/build.gradle
+++ b/choreo-extension-ballerina/build.gradle
@@ -38,7 +38,6 @@ dependencies {
     externalJars "io.opentelemetry:opentelemetry-sdk-common:${openTelemetryVersion}"
     externalJars "io.opentelemetry:opentelemetry-sdk-trace:${openTelemetryVersion}"
     externalJars "io.opentelemetry:opentelemetry-semconv:${openTelemetryAlphaVersion}"
-    externalJars "io.opentelemetry:opentelemetry-api-metrics:${openTelemetryAlphaVersion}"
     externalJars "io.opentelemetry:opentelemetry-extension-trace-propagators:${openTelemetryVersion}"
     externalJars "io.grpc:grpc-protobuf:${grpcVersion}"
     externalJars "io.grpc:grpc-stub:${grpcVersion}"

--- a/choreo-extension-native/build.gradle
+++ b/choreo-extension-native/build.gradle
@@ -28,7 +28,7 @@ dependencies {
     implementation "io.opentelemetry:opentelemetry-sdk-common:${openTelemetryVersion}"
     implementation "io.opentelemetry:opentelemetry-sdk-trace:${openTelemetryVersion}"
     implementation "io.opentelemetry:opentelemetry-semconv:${openTelemetryAlphaVersion}"
-    implementation "io.opentelemetry:opentelemetry-api-metrics:${openTelemetryAlphaVersion}"
+
     implementation "io.opentelemetry:opentelemetry-extension-trace-propagators:${openTelemetryVersion}"
     implementation "io.jaegertracing:jaeger-core:${jaegerVersion}"
     implementation("com.google.guava:guava:${guavaVersion}") {

--- a/choreo-extension-native/src/main/java/io/ballerina/observe/choreo/sampler/RateLimitingSampler.java
+++ b/choreo-extension-native/src/main/java/io/ballerina/observe/choreo/sampler/RateLimitingSampler.java
@@ -9,7 +9,7 @@ import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.SpanContext;
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.context.Context;
-import io.opentelemetry.sdk.internal.SystemClock;
+import io.opentelemetry.sdk.common.Clock;
 import io.opentelemetry.sdk.trace.data.LinkData;
 import io.opentelemetry.sdk.trace.samplers.Sampler;
 import io.opentelemetry.sdk.trace.samplers.SamplingDecision;
@@ -38,7 +38,7 @@ public class RateLimitingSampler implements Sampler {
     public RateLimitingSampler(int maxTracesPerSecond) {
         this.maxTracesPerSecond = maxTracesPerSecond;
         double maxBalance = maxTracesPerSecond < 1.0 ? 1.0 : maxTracesPerSecond;
-        this.rateLimiter = new RateLimiter(maxTracesPerSecond, maxBalance, SystemClock.getInstance());
+        this.rateLimiter = new RateLimiter(maxTracesPerSecond, maxBalance, Clock.getDefault());
         Attributes attributes = Attributes.empty();
         this.onSamplingResult = SamplingResult.create(SamplingDecision.RECORD_AND_SAMPLE, attributes);
         this.offSamplingResult = SamplingResult.create(SamplingDecision.DROP, attributes);

--- a/gradle.properties
+++ b/gradle.properties
@@ -22,7 +22,7 @@ org.gradle.workers.max=3
 
 # Native Dependency Versions
 jaegerVersion=1.8.1
-openTelemetryVersion=1.0.0
+openTelemetryVersion=1.63.0
 openTelemetryAlphaVersion=1.0.0-alpha
 guavaVersion=31.1-jre
 failureAccessVersion=1.0.1


### PR DESCRIPTION
## Summary

- Upgrades `opentelemetry-api` and `opentelemetry-extension-trace-propagators` from **1.0.0 → 1.63.0** to address CVE-2026-45292 (Unbounded Memory Allocation in W3C Baggage Propagation — DoS)
- Affected versions ≤ 1.61.0; fix is present in 1.62.0+
- Handles breaking changes introduced between 1.0.0 and 1.63.0 (see details below)

Fixes https://github.com/ballerina-platform/ballerina-lang/issues/44622

## CVE Details

**CVE-2026-45292**: `W3CBaggagePropagator` and `OtTracePropagator` iterated through propagation headers without size limits, allowing heap memory exhaustion via crafted HTTP headers.
Affected artifacts: `opentelemetry-api` and `opentelemetry-extension-trace-propagators` ≤ 1.61.0.

## Breaking Changes Addressed

| Change | Detail |
|--------|--------|
| `opentelemetry-api-metrics:1.0.0-alpha` removed | Merged into `opentelemetry-api` in 1.10.0. Removed from `build.gradle` (was already unused in Java source — Choreo uses Ballerina runtime metrics). |
| `io.opentelemetry.sdk.internal.SystemClock` removed | Internal class dropped. Replaced with `Clock.getDefault()` in `RateLimitingSampler.java`. |

## Test plan

- [ ] CI build passes (Java 17, ubuntu-latest, `./gradlew clean build`)
- [ ] Compilation succeeds with all OTel API calls resolved

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Updated OpenTelemetry dependencies to a newer release and aligned the native extension code with the updated APIs. This includes removing the unused `opentelemetry-api-metrics` dependency, switching `RateLimitingSampler` to use `Clock.getDefault()`, and bumping the shared OpenTelemetry version in Gradle.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->